### PR TITLE
feat: add E2E test suite with smoke test mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Run tests with pytest and coverage
       run: |
-        poetry run pytest --cov=taskmanagement_app --cov-report=xml --cov-report=term-missing --junitxml=junit.xml -o junit_family=legacy tests/
+        poetry run pytest --cov=taskmanagement_app --cov-report=xml --cov-report=term-missing --junitxml=junit.xml -o junit_family=legacy --ignore=tests/e2e tests/
 
     - name: Build wheel
       if: success()
@@ -136,3 +136,66 @@ jobs:
         name: mutation-testing-report
         path: mutation-report/
         if-no-files-found: warn
+
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: backend-checks
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.14'
+
+    - name: Install poetry
+      run: pip install poetry
+
+    - name: Setup a local virtual environment (if no poetry.toml file)
+      run: |
+        poetry config virtualenvs.create true --local
+        poetry config virtualenvs.in-project true --local
+
+    - uses: actions/cache@v5
+      name: Define a cache for the virtual environment based on the dependencies lock file
+      with:
+        path: ./.venv
+        key: venv-${{ hashFiles('poetry.lock') }}
+
+    - name: Install dependencies
+      run: poetry install
+
+    - name: Apply database migrations
+      run: poetry run alembic upgrade head
+
+    - name: Start FastAPI server
+      run: |
+        poetry run uvicorn taskmanagement_app.main:app --host 0.0.0.0 --port 8000 &
+        echo $! > /tmp/uvicorn.pid
+
+    - name: Wait for server readiness
+      run: |
+        for i in $(seq 1 30); do
+          if curl -sf http://localhost:8000/openapi.json > /dev/null 2>&1; then
+            echo "Server is ready"
+            exit 0
+          fi
+          echo "Waiting for server... ($i/30)"
+          sleep 2
+        done
+        echo "Server failed to start within 60 seconds"
+        exit 1
+
+    - name: Run E2E tests
+      run: poetry run pytest tests/e2e/ -v --tb=short
+
+    - name: Stop FastAPI server
+      if: always()
+      run: |
+        if [ -f /tmp/uvicorn.pid ]; then
+          kill "$(cat /tmp/uvicorn.pid)" 2>/dev/null || true
+          rm -f /tmp/uvicorn.pid
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       run: poetry install
 
     - name: Run mutation testing with pytest-gremlins
-      run: poetry run pytest --gremlins --gremlin-parallel --gremlin-cache --gremlin-report=html --gremlins-html-dir=mutation-report tests/
+      run: poetry run pytest --gremlins --gremlin-parallel --gremlin-cache --gremlin-report=html --gremlins-html-dir=mutation-report --ignore=tests/e2e tests/
 
     - name: Upload mutation testing report
       if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,3 +129,41 @@ jobs:
           fi
           WHEEL_PATH="${wheels[0]}"
           sudo /opt/taskmanagement-app/deploy/deploy-wheel.sh "$WHEEL_PATH"
+
+  smoke-test:
+    name: Post-Deploy Smoke Test
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install poetry
+        run: pip install poetry
+
+      - name: Setup a local virtual environment (if no poetry.toml file)
+        run: |
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
+
+      - uses: actions/cache@v5
+        name: Define a cache for the virtual environment based on the dependencies lock file
+        with:
+          path: ./.venv
+          key: venv-${{ hashFiles('poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run smoke tests against deployed environment
+        env:
+          E2E_BASE_URL: ${{ secrets.DEPLOY_URL }}
+          E2E_USERNAME: ${{ secrets.E2E_USERNAME }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+        run: poetry run pytest tests/e2e/ -m smoke -v --tb=short

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,172 @@
+# Taskmanagement-App — Backend
+
+Python / FastAPI / Poetry / SQLAlchemy / Alembic / mypy / pytest
+
+## Quick Commands
+
+```bash
+poetry run uvicorn taskmanagement_app.main:app --reload   # dev server (port 8000)
+poetry run alembic upgrade head                           # apply migrations
+poetry run pytest --cov                                   # run tests
+poetry run black . && poetry run isort . && poetry run flake8 && poetry run mypy .  # quality checks
+```
+
+## Quality Gates (all must pass before a PR)
+
+| Tool | Purpose |
+|---|---|
+| `black` | formatting (line length 88) |
+| `isort` | import order (black profile) |
+| `flake8` | lint (max-line-length 88) |
+| `mypy` | type checking |
+| `pytest` | tests with coverage |
+
+## Deployment Rule
+
+**Always bump `pyproject.toml` version when backend changes should reach production.** The deploy pipeline only fires when the version changes. Use semver: `patch` / `minor` / `major`.
+
+## Adding a Feature (checklist)
+
+1. Create or update SQLAlchemy model in `db/models/`
+2. Generate + apply Alembic migration: `poetry run alembic revision --autogenerate -m "description"` then `upgrade head`
+3. Create/update Pydantic schemas in `schemas/`
+4. Implement CRUD in `crud/`
+5. Wire endpoint in `api/v1/endpoints/`
+6. Write tests in `tests/`
+7. Run all quality checks
+
+## E2E Tests
+
+End-to-end tests live in `tests/e2e/` and run against a **live server** (not TestClient).
+
+```bash
+# Start the server first
+poetry run uvicorn taskmanagement_app.main:app --reload &
+
+# Smoke tests only (read-only, safe for production)
+poetry run pytest tests/e2e/ -m smoke -v
+
+# Full suite (includes write operations — local/CI only)
+poetry run pytest tests/e2e/ -v
+```
+
+**Two modes:**
+- `@pytest.mark.smoke` — read-only tests that verify API health. Run post-deployment against production.
+- Full suite — includes CRUD lifecycle, user management, data export/import. Creates and cleans up test data.
+
+**Credentials:** The conftest auto-loads `.env` for admin credentials and bootstraps a temporary test user via the admin API. Override with env vars: `E2E_BASE_URL`, `E2E_USERNAME`, `E2E_PASSWORD`, `E2E_ADMIN_USERNAME`, `E2E_ADMIN_PASSWORD`.
+
+**CI integration:** The `e2e-tests` job in `ci.yml` runs the full suite on PRs. The `smoke-test` job in `deploy.yml` runs smoke tests after deployment (requires `DEPLOY_URL`, `E2E_USERNAME`, `E2E_PASSWORD` secrets).
+
+## API Docs (when server is running)
+
+- Swagger: http://localhost:8000/docs
+- OpenAPI JSON: http://localhost:8000/openapi.json
+
+## Further Reading
+
+- Code style, patterns, and conventions: [.github/copilot-instructions.md](.github/copilot-instructions.md)
+- Production deployment (systemd + GitHub Actions): [README_DEPLOYMENT.md](README_DEPLOYMENT.md)
+- PR workflow and version bump rules: [../docs/pr-workflow.md](../docs/pr-workflow.md)
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **Taskmanagement-App** (896 symbols, 3075 relationships, 73 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/Taskmanagement-App/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/Taskmanagement-App/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/Taskmanagement-App/clusters` | All functional areas |
+| `gitnexus://repo/Taskmanagement-App/processes` | All execution flows |
+| `gitnexus://repo/Taskmanagement-App/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Dockerfile for E2E testing (lightweight, no persistent DB)
+FROM python:3.14-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install poetry
+RUN pip install --no-cache-dir poetry
+
+# Copy dependency files first (better layer caching)
+COPY pyproject.toml poetry.lock ./
+
+# Install dependencies (no dev deps for smaller image)
+RUN poetry config virtualenvs.create false \
+    && poetry install --only main --no-interaction --no-ansi
+
+# Copy application code
+COPY taskmanagement_app ./taskmanagement_app
+COPY alembic.ini ./
+COPY migrations ./migrations
+
+# Create a non-root user
+RUN useradd -m appuser && chown -R appuser:appuser /app
+USER appuser
+
+# Expose port
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8000/docs || exit 1
+
+# Run with uvicorn
+CMD ["python", "-m", "uvicorn", "taskmanagement_app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "taskmanagement_app"
-version = "0.13.4"
+version = "0.13.5"
 description = "A task management application"
 authors = ["Hannes Brandstätter-Müller <hannes.mueller@gmail.com>"]
 readme = "README.md"
@@ -133,6 +133,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v --cov=taskmanagement_app --cov-report=term-missing"
+markers = [
+    "smoke: Lightweight smoke tests that verify basic API health",
+]
 filterwarnings = [
     "ignore::DeprecationWarning",
     "ignore::UserWarning",

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 testpaths = tests
 python_files = test_*.py
 python_functions = test_*
+markers =
+    smoke: Lightweight smoke tests that verify basic API health (read-only, safe for production)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -80,21 +80,30 @@ def http_client(base_url: str) -> Generator[httpx.Client, None, None]:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="session")
-def admin_token(base_url: str) -> str:
-    """Bearer token for the superadmin user."""
+def _get_admin_token(base_url: str) -> str:
+    """Obtain admin token (helper, not a fixture to avoid eager resolution)."""
     username = os.environ.get("E2E_ADMIN_USERNAME", _DEFAULT_ADMIN_USERNAME)
     password = os.environ.get("E2E_ADMIN_PASSWORD", _DEFAULT_ADMIN_PASSWORD)
     return _obtain_token(base_url, username, password)
 
 
 @pytest.fixture(scope="session")
-def auth_token(base_url: str, admin_token: str) -> Generator[str, None, None]:
+def admin_token(base_url: str) -> str:
+    """Bearer token for the superadmin user."""
+    return _get_admin_token(base_url)
+
+
+@pytest.fixture(scope="session")
+def auth_token(base_url: str) -> Generator[str, None, None]:
     """Bearer token for a regular (non-admin) user.
 
     If E2E_USERNAME / E2E_PASSWORD are set, uses those credentials.
     Otherwise, creates a temporary test user via the admin API and
     cleans it up when the session ends.
+
+    Note: This fixture does NOT depend on admin_token to avoid requiring
+    admin credentials when E2E_USERNAME/E2E_PASSWORD are provided (e.g.,
+    in production smoke tests).
     """
     username = os.environ.get("E2E_USERNAME", "")
     password = os.environ.get("E2E_PASSWORD", "")
@@ -103,10 +112,11 @@ def auth_token(base_url: str, admin_token: str) -> Generator[str, None, None]:
         yield _obtain_token(base_url, username, password)
         return
 
-    # Auto-bootstrap a temporary test user
+    # Auto-bootstrap a temporary test user (requires admin credentials)
+    admin_tok = _get_admin_token(base_url)
     user_id = None
     with httpx.Client(base_url=base_url, timeout=_DEFAULT_TIMEOUT) as client:
-        headers = {"Authorization": f"Bearer {admin_token}"}
+        headers = {"Authorization": f"Bearer {admin_tok}"}
         resp = client.post(
             "/api/v1/admin/users",
             json={"email": _TEST_USER_EMAIL, "password": _TEST_USER_PASSWORD},
@@ -126,7 +136,7 @@ def auth_token(base_url: str, admin_token: str) -> Generator[str, None, None]:
     # Teardown: delete the temporary user
     if user_id is not None:
         with httpx.Client(base_url=base_url, timeout=_DEFAULT_TIMEOUT) as client:
-            headers = {"Authorization": f"Bearer {admin_token}"}
+            headers = {"Authorization": f"Bearer {admin_tok}"}
             client.delete(f"/api/v1/admin/users/{user_id}", headers=headers)
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,161 @@
+"""
+E2E test fixtures.
+
+Provides httpx-based clients that talk to a running instance of the
+application (local dev server by default, or whatever E2E_BASE_URL
+points to).
+
+Credentials are read from environment variables. When running locally,
+the project's .env file is loaded automatically so that admin credentials
+match the running server.
+
+If E2E_USERNAME / E2E_PASSWORD are not set, a temporary test user is
+created via the admin API and cleaned up at the end of the session.
+"""
+
+import os
+from pathlib import Path
+from typing import Generator
+
+import httpx
+import pytest
+from dotenv import load_dotenv
+
+# Load .env from the project root so local runs pick up ADMIN_USERNAME etc.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+load_dotenv(_PROJECT_ROOT / ".env")
+
+# ---------------------------------------------------------------------------
+# Configuration from environment
+# ---------------------------------------------------------------------------
+
+_DEFAULT_BASE_URL = "http://localhost:8000"
+_DEFAULT_ADMIN_USERNAME = os.environ.get("ADMIN_USERNAME", "admin")
+_DEFAULT_ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "admin")
+
+_TOKEN_PATH = "/api/v1/auth/user/token"
+_DEFAULT_TIMEOUT = 30.0
+
+_TEST_USER_EMAIL = "e2e-test-user@example.com"
+_TEST_USER_PASSWORD = "E2eTestPass-123"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _obtain_token(base_url: str, username: str, password: str) -> str:
+    """Authenticate via the OAuth2 password flow and return a bearer token."""
+    with httpx.Client(base_url=base_url, timeout=_DEFAULT_TIMEOUT) as client:
+        response = client.post(
+            _TOKEN_PATH,
+            data={"username": username, "password": password},
+        )
+        response.raise_for_status()
+        token: str = response.json()["access_token"]
+        return token
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — base URL & plain client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    """Base URL of the running application under test."""
+    return os.environ.get("E2E_BASE_URL", _DEFAULT_BASE_URL)
+
+
+@pytest.fixture(scope="function")
+def http_client(base_url: str) -> Generator[httpx.Client, None, None]:
+    """Unauthenticated httpx client pointed at the application."""
+    with httpx.Client(base_url=base_url, timeout=_DEFAULT_TIMEOUT) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — authentication tokens (session-scoped for speed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def admin_token(base_url: str) -> str:
+    """Bearer token for the superadmin user."""
+    username = os.environ.get("E2E_ADMIN_USERNAME", _DEFAULT_ADMIN_USERNAME)
+    password = os.environ.get("E2E_ADMIN_PASSWORD", _DEFAULT_ADMIN_PASSWORD)
+    return _obtain_token(base_url, username, password)
+
+
+@pytest.fixture(scope="session")
+def auth_token(base_url: str, admin_token: str) -> Generator[str, None, None]:
+    """Bearer token for a regular (non-admin) user.
+
+    If E2E_USERNAME / E2E_PASSWORD are set, uses those credentials.
+    Otherwise, creates a temporary test user via the admin API and
+    cleans it up when the session ends.
+    """
+    username = os.environ.get("E2E_USERNAME", "")
+    password = os.environ.get("E2E_PASSWORD", "")
+
+    if username and password:
+        yield _obtain_token(base_url, username, password)
+        return
+
+    # Auto-bootstrap a temporary test user
+    user_id = None
+    with httpx.Client(base_url=base_url, timeout=_DEFAULT_TIMEOUT) as client:
+        headers = {"Authorization": f"Bearer {admin_token}"}
+        resp = client.post(
+            "/api/v1/admin/users",
+            json={"email": _TEST_USER_EMAIL, "password": _TEST_USER_PASSWORD},
+            headers=headers,
+        )
+        if resp.status_code in (200, 201):
+            user_id = resp.json()["id"]
+        elif resp.status_code == 400:
+            # User already exists (leftover from a previous run) — reuse it
+            pass
+        else:
+            resp.raise_for_status()
+
+    token = _obtain_token(base_url, _TEST_USER_EMAIL, _TEST_USER_PASSWORD)
+    yield token
+
+    # Teardown: delete the temporary user
+    if user_id is not None:
+        with httpx.Client(base_url=base_url, timeout=_DEFAULT_TIMEOUT) as client:
+            headers = {"Authorization": f"Bearer {admin_token}"}
+            client.delete(f"/api/v1/admin/users/{user_id}", headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — authenticated clients (function-scoped)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+def authed_client(
+    base_url: str, auth_token: str
+) -> Generator[httpx.Client, None, None]:
+    """httpx client with a regular-user Authorization header."""
+    with httpx.Client(
+        base_url=base_url,
+        timeout=_DEFAULT_TIMEOUT,
+        headers={"Authorization": f"Bearer {auth_token}"},
+    ) as client:
+        yield client
+
+
+@pytest.fixture(scope="function")
+def admin_client(
+    base_url: str, admin_token: str
+) -> Generator[httpx.Client, None, None]:
+    """httpx client with an admin Authorization header."""
+    with httpx.Client(
+        base_url=base_url,
+        timeout=_DEFAULT_TIMEOUT,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    ) as client:
+        yield client

--- a/tests/e2e/test_data_operations.py
+++ b/tests/e2e/test_data_operations.py
@@ -1,0 +1,126 @@
+"""E2E tests — data export and import operations.
+
+Requires admin privileges and a running dev server.
+"""
+
+import uuid
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_EXPORT_URL = "/api/v1/admin/data/export"
+_IMPORT_URL = "/api/v1/admin/data/import"
+_TASKS_URL = "/api/v1/tasks"
+_ADMIN_USERS_URL = "/api/v1/admin/users"
+_ME_URL = "/api/v1/users/me"
+
+# A password that satisfies: >=8 chars, upper, lower, digit, special char
+_STRONG_PASSWORD = "E2eTest!42"
+
+
+def _unique(prefix: str = "e2e") -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestExportData:
+    """GET /api/v1/admin/data/export returns valid export payload."""
+
+    def test_export_data(self, admin_client: httpx.Client) -> None:
+        resp = admin_client.get(_EXPORT_URL)
+        assert resp.status_code == 200
+
+        data = resp.json()
+        # Must have the expected top-level keys
+        assert "version" in data
+        assert "users" in data
+        assert "tasks" in data
+
+        # version should be a positive integer
+        assert isinstance(data["version"], int)
+        assert data["version"] >= 1
+
+        # users and tasks should be lists
+        assert isinstance(data["users"], list)
+        assert isinstance(data["tasks"], list)
+
+        # If there are users, verify each has expected fields
+        if data["users"]:
+            user = data["users"][0]
+            for field in ("id", "email", "is_active", "is_admin"):
+                assert field in user, f"Missing field '{field}' in exported user"
+
+        # If there are tasks, verify each has expected fields
+        if data["tasks"]:
+            task = data["tasks"][0]
+            for field in ("id", "title", "description", "state"):
+                assert field in task, f"Missing field '{field}' in exported task"
+
+
+class TestImportExportRoundtrip:
+    """Export data, create a task, export again, then import the first snapshot."""
+
+    def test_import_export_roundtrip(
+        self, admin_client: httpx.Client, authed_client: httpx.Client
+    ) -> None:
+        # 1. Create a uniquely named task so we can track it
+        tag = _unique("roundtrip")
+
+        # Get the authed user's ID for created_by
+        me_resp = authed_client.get(_ME_URL)
+        me_resp.raise_for_status()
+        user_id = me_resp.json()["id"]
+
+        create_resp = authed_client.post(
+            _TASKS_URL,
+            json={
+                "title": tag,
+                "description": "roundtrip test task",
+                "created_by": user_id,
+            },
+        )
+        assert create_resp.status_code == 200
+        created_task_id = create_resp.json()["id"]
+
+        try:
+            # 2. Export — the new task must be in the export
+            export_resp = admin_client.get(_EXPORT_URL)
+            assert export_resp.status_code == 200
+            export_data = export_resp.json()
+
+            # Verify our task appears in the export
+            exported_titles = [t["title"] for t in export_data["tasks"]]
+            assert tag in exported_titles, f"Task '{tag}' not found in export"
+
+            # 3. Import the same export payload back
+            import_resp = admin_client.post(_IMPORT_URL, json=export_data)
+            assert import_resp.status_code == 200
+            result = import_resp.json()
+
+            # Verify the import result has the expected shape
+            assert "users_imported" in result
+            assert "users_skipped" in result
+            assert "tasks_imported" in result
+            assert "tasks_skipped" in result
+
+            # The import processed our tasks (imported or skipped)
+            total_processed = result["tasks_imported"] + result["tasks_skipped"]
+            assert total_processed >= 1, "Import should process at least one task"
+
+            # Clean up any duplicates created by the import
+            list_resp = authed_client.get(_TASKS_URL, params={"show_all": True})
+            if list_resp.status_code == 200:
+                for t in list_resp.json():
+                    if t["title"] == tag and t["id"] != created_task_id:
+                        authed_client.delete(f"{_TASKS_URL}/{t['id']}")
+
+        finally:
+            # Cleanup — archive the task we created
+            authed_client.delete(f"{_TASKS_URL}/{created_task_id}")

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -52,8 +52,13 @@ class TestSmoke:
 
     def test_auth_valid_credentials(self, http_client, base_url):
         """POST /api/v1/auth/user/token with valid creds returns a token."""
-        username = os.environ.get("ADMIN_USERNAME", "admin")
-        password = os.environ.get("ADMIN_PASSWORD", "admin")
+        # Use E2E credentials (smoke test user), fall back to admin for local dev
+        username = os.environ.get("E2E_USERNAME") or os.environ.get(
+            "ADMIN_USERNAME", "admin"
+        )
+        password = os.environ.get("E2E_PASSWORD") or os.environ.get(
+            "ADMIN_PASSWORD", "admin"
+        )
         resp = http_client.post(
             _TOKEN_PATH,
             data={"username": username, "password": password},

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1,0 +1,126 @@
+"""
+Smoke tests — fast, read-only checks that the API is alive and wired up.
+
+Every test in this module is marked ``@pytest.mark.smoke`` so CI can run
+the smoke suite independently::
+
+    poetry run pytest -m smoke
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+# Load .env so admin credentials match the running server.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+load_dotenv(_PROJECT_ROOT / ".env")
+
+_TOKEN_PATH = "/api/v1/auth/user/token"
+
+
+@pytest.mark.smoke
+class TestSmoke:
+    """Read-only smoke tests for core API endpoints."""
+
+    # ------------------------------------------------------------------
+    # Docs / schema
+    # ------------------------------------------------------------------
+
+    def test_swagger_ui_loads(self, http_client):
+        """GET /docs returns 200 with Swagger UI HTML."""
+        resp = http_client.get("/docs")
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        assert "text/html" in resp.headers.get(
+            "content-type", ""
+        ), "Response should be HTML"
+        assert "swagger" in resp.text.lower(), "Page should contain Swagger UI"
+
+    def test_openapi_schema(self, http_client):
+        """GET /openapi.json returns 200 with a valid OpenAPI schema."""
+        resp = http_client.get("/openapi.json")
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        body = resp.json()
+        assert "openapi" in body, "Schema must contain 'openapi' version key"
+        assert "paths" in body, "Schema must contain 'paths'"
+        assert "info" in body, "Schema must contain 'info'"
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
+
+    def test_auth_valid_credentials(self, http_client, base_url):
+        """POST /api/v1/auth/user/token with valid creds returns a token."""
+        username = os.environ.get("ADMIN_USERNAME", "admin")
+        password = os.environ.get("ADMIN_PASSWORD", "admin")
+        resp = http_client.post(
+            _TOKEN_PATH,
+            data={"username": username, "password": password},
+        )
+        assert resp.status_code == 200, (
+            f"Expected 200 for valid credentials, got {resp.status_code}: "
+            f"{resp.text}"
+        )
+        body = resp.json()
+        assert "access_token" in body, "Response must contain 'access_token'"
+        assert (
+            body.get("token_type", "").lower() == "bearer"
+        ), "token_type should be 'bearer'"
+
+    def test_auth_invalid_credentials(self, http_client):
+        """POST /api/v1/auth/user/token with bad creds returns 401."""
+        resp = http_client.post(
+            _TOKEN_PATH,
+            data={
+                "username": "nonexistent@example.com",
+                "password": "wrong_password",
+            },
+        )
+        assert (
+            resp.status_code == 401
+        ), f"Expected 401 for invalid credentials, got {resp.status_code}"
+
+    # ------------------------------------------------------------------
+    # Tasks
+    # ------------------------------------------------------------------
+
+    def test_task_list(self, authed_client):
+        """GET /api/v1/tasks returns 200 with a list."""
+        resp = authed_client.get("/api/v1/tasks")
+        assert (
+            resp.status_code == 200
+        ), f"Expected 200 for task list, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert isinstance(body, list), "Task list response should be a JSON array"
+
+    # ------------------------------------------------------------------
+    # Users
+    # ------------------------------------------------------------------
+
+    def test_current_user(self, authed_client):
+        """GET /api/v1/users/me returns 200 with user info."""
+        resp = authed_client.get("/api/v1/users/me")
+        assert (
+            resp.status_code == 200
+        ), f"Expected 200 for /users/me, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert "email" in body, "User response must contain 'email'"
+        assert "id" in body, "User response must contain 'id'"
+
+    def test_current_user_unauthorized(self, http_client):
+        """GET /api/v1/users/me without a token returns 401."""
+        resp = http_client.get("/api/v1/users/me")
+        assert (
+            resp.status_code == 401
+        ), f"Expected 401 without auth, got {resp.status_code}"
+
+    def test_user_list(self, authed_client):
+        """GET /api/v1/users returns 200 with a list."""
+        resp = authed_client.get("/api/v1/users")
+        assert (
+            resp.status_code == 200
+        ), f"Expected 200 for user list, got {resp.status_code}: {resp.text}"
+        body = resp.json()
+        assert isinstance(body, list), "User list response should be a JSON array"
+        assert len(body) >= 1, "User list should contain at least one user"

--- a/tests/e2e/test_task_lifecycle.py
+++ b/tests/e2e/test_task_lifecycle.py
@@ -1,0 +1,150 @@
+"""E2E tests — full CRUD lifecycle for tasks.
+
+Tests exercise the running application via HTTP (not the test client),
+so the dev server must be up at E2E_BASE_URL (default http://localhost:8000).
+"""
+
+import uuid
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TASKS_URL = "/api/v1/tasks"
+_ME_URL = "/api/v1/users/me"
+
+
+def _unique_title(prefix: str = "e2e-task") -> str:
+    """Return a collision-free task title."""
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def _get_current_user_id(client: httpx.Client) -> int:
+    """Return the authenticated user's ID via GET /users/me."""
+    resp = client.get(_ME_URL)
+    resp.raise_for_status()
+    user_id: int = resp.json()["id"]
+    return user_id
+
+
+def _create_task(
+    client: httpx.Client,
+    *,
+    title: str | None = None,
+    description: str = "e2e test task",
+    created_by: int | None = None,
+) -> dict:
+    """Create a task and return the response JSON. Raises on failure."""
+    if created_by is None:
+        created_by = _get_current_user_id(client)
+    payload = {
+        "title": title or _unique_title(),
+        "description": description,
+        "created_by": created_by,
+    }
+    resp = client.post(_TASKS_URL, json=payload)
+    resp.raise_for_status()
+    data: dict = resp.json()
+    return data
+
+
+def _delete_task(client: httpx.Client, task_id: int) -> None:
+    """Best-effort cleanup: archive (DELETE) the task."""
+    client.delete(f"{_TASKS_URL}/{task_id}")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTask:
+    """POST /api/v1/tasks creates a task."""
+
+    def test_create_task(self, authed_client: httpx.Client) -> None:
+        title = _unique_title("create")
+        task = _create_task(authed_client, title=title, description="verify creation")
+
+        try:
+            assert task["title"] == title
+            assert task["description"] == "verify creation"
+            assert task["state"] == "todo"
+            assert "id" in task
+            assert task["id"] > 0
+        finally:
+            _delete_task(authed_client, task["id"])
+
+
+class TestUpdateTask:
+    """PATCH /api/v1/tasks/{id} updates a task."""
+
+    def test_update_task(self, authed_client: httpx.Client) -> None:
+        task = _create_task(authed_client)
+        task_id = task["id"]
+
+        try:
+            new_title = _unique_title("updated")
+            resp = authed_client.patch(
+                f"{_TASKS_URL}/{task_id}",
+                json={"title": new_title, "description": "patched desc"},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["title"] == new_title
+            assert body["description"] == "patched desc"
+            # State should remain unchanged
+            assert body["state"] == "todo"
+        finally:
+            _delete_task(authed_client, task_id)
+
+
+class TestTaskStateTransitions:
+    """POST start -> complete -> DELETE (archive) lifecycle."""
+
+    def test_task_state_transitions(self, authed_client: httpx.Client) -> None:
+        task = _create_task(authed_client)
+        task_id = task["id"]
+
+        try:
+            # 1. Start the task  (todo -> in_progress)
+            resp = authed_client.post(f"{_TASKS_URL}/{task_id}/start")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["state"] == "in_progress"
+            assert body["started_at"] is not None
+
+            # 2. Complete the task  (in_progress -> done)
+            resp = authed_client.post(f"{_TASKS_URL}/{task_id}/complete")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["state"] == "done"
+            assert body["completed_at"] is not None
+
+            # 3. Archive the task  (done -> archived via DELETE)
+            resp = authed_client.delete(f"{_TASKS_URL}/{task_id}")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["state"] == "archived"
+        finally:
+            # Cleanup is already done by the archive step; extra call is harmless
+            _delete_task(authed_client, task_id)
+
+
+class TestTaskAppearsInList:
+    """Created task is visible in GET /api/v1/tasks."""
+
+    def test_task_appears_in_list(self, authed_client: httpx.Client) -> None:
+        task = _create_task(authed_client)
+        task_id = task["id"]
+
+        try:
+            resp = authed_client.get(_TASKS_URL, params={"show_all": True})
+            assert resp.status_code == 200
+            tasks = resp.json()
+            matching = [t for t in tasks if t["id"] == task_id]
+            assert len(matching) == 1, f"Task {task_id} not found in task list"
+            assert matching[0]["title"] == task["title"]
+        finally:
+            _delete_task(authed_client, task_id)

--- a/tests/e2e/test_user_management.py
+++ b/tests/e2e/test_user_management.py
@@ -1,0 +1,162 @@
+"""E2E tests — admin user management operations.
+
+Covers user creation, password changes, and role assignment.
+Requires the dev server to be running at E2E_BASE_URL.
+"""
+
+import uuid
+
+import httpx
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_ADMIN_USERS_URL = "/api/v1/admin/users"
+_TOKEN_URL = "/api/v1/auth/user/token"
+_ME_URL = "/api/v1/users/me"
+_ME_PASSWORD_URL = "/api/v1/users/me/password"
+
+
+def _unique_email() -> str:
+    return f"e2e-{uuid.uuid4().hex[:8]}@test.example.com"
+
+
+# A password that satisfies: >=8 chars, upper, lower, digit, special char
+_STRONG_PASSWORD = "E2eTest!42"
+_STRONG_PASSWORD_ALT = "AltPass#99"
+
+
+def _login(base_url: str, email: str, password: str) -> str:
+    """Obtain a bearer token for *email* / *password*. Raises on failure."""
+    with httpx.Client(base_url=base_url, timeout=30.0) as client:
+        resp = client.post(
+            _TOKEN_URL,
+            data={"username": email, "password": password},
+        )
+        resp.raise_for_status()
+        token: str = resp.json()["access_token"]
+        return token
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdminCreateUser:
+    """Admin creates a user, verifies the user can log in, then deletes."""
+
+    def test_admin_create_user(self, admin_client: httpx.Client, base_url: str) -> None:
+        email = _unique_email()
+        # 1. Admin creates the user
+        resp = admin_client.post(
+            _ADMIN_USERS_URL,
+            json={"email": email, "password": _STRONG_PASSWORD, "is_admin": False},
+        )
+        assert resp.status_code == 200
+        user = resp.json()
+        user_id = user["id"]
+
+        try:
+            assert user["email"] == email
+            assert user["is_active"] is True
+            assert user["is_admin"] is False
+
+            # 2. Verify the new user can log in
+            token = _login(base_url, email, _STRONG_PASSWORD)
+            assert token  # non-empty string
+
+        finally:
+            # 3. Cleanup — admin deletes the user
+            del_resp = admin_client.delete(f"{_ADMIN_USERS_URL}/{user_id}")
+            assert del_resp.status_code == 200
+
+
+class TestPasswordChange:
+    """User changes their own password, verifies new password works."""
+
+    def test_password_change(self, admin_client: httpx.Client, base_url: str) -> None:
+        email = _unique_email()
+        # Setup: admin creates a throwaway user
+        resp = admin_client.post(
+            _ADMIN_USERS_URL,
+            json={"email": email, "password": _STRONG_PASSWORD, "is_admin": False},
+        )
+        assert resp.status_code == 200
+        user_id = resp.json()["id"]
+
+        try:
+            # 1. Log in as the new user
+            token = _login(base_url, email, _STRONG_PASSWORD)
+            user_headers = {"Authorization": f"Bearer {token}"}
+
+            with httpx.Client(
+                base_url=base_url, timeout=30.0, headers=user_headers
+            ) as user_client:
+                # 2. Change password
+                change_resp = user_client.put(
+                    _ME_PASSWORD_URL,
+                    json={
+                        "current_password": _STRONG_PASSWORD,
+                        "new_password": _STRONG_PASSWORD_ALT,
+                    },
+                )
+                assert change_resp.status_code == 200
+
+            # 3. Verify new password works
+            new_token = _login(base_url, email, _STRONG_PASSWORD_ALT)
+            assert new_token
+
+            # 4. Verify old password no longer works
+            with pytest.raises(httpx.HTTPStatusError) as exc_info:
+                _login(base_url, email, _STRONG_PASSWORD)
+            assert exc_info.value.response.status_code == 401
+
+        finally:
+            # Cleanup — admin deletes the user
+            admin_client.delete(f"{_ADMIN_USERS_URL}/{user_id}")
+
+
+class TestRoleAssignment:
+    """Admin changes a user's role and verifies the change persists."""
+
+    def test_role_assignment(self, admin_client: httpx.Client) -> None:
+        email = _unique_email()
+        # Setup: admin creates a non-admin user
+        resp = admin_client.post(
+            _ADMIN_USERS_URL,
+            json={"email": email, "password": _STRONG_PASSWORD, "is_admin": False},
+        )
+        assert resp.status_code == 200
+        user_id = resp.json()["id"]
+
+        try:
+            # 1. Promote to admin
+            role_resp = admin_client.patch(
+                f"{_ADMIN_USERS_URL}/{user_id}/role",
+                json={"is_admin": True},
+            )
+            assert role_resp.status_code == 200
+            assert role_resp.json()["is_admin"] is True
+
+            # 2. Verify the change persists by re-fetching the user list
+            list_resp = admin_client.get(_ADMIN_USERS_URL)
+            assert list_resp.status_code == 200
+            users = list_resp.json()
+            target = [u for u in users if u["id"] == user_id]
+            assert len(target) == 1
+            assert target[0]["is_admin"] is True
+
+            # 3. Demote back to regular user (restore original state)
+            role_resp = admin_client.patch(
+                f"{_ADMIN_USERS_URL}/{user_id}/role",
+                json={"is_admin": False},
+            )
+            assert role_resp.status_code == 200
+            assert role_resp.json()["is_admin"] is False
+
+        finally:
+            # Cleanup — admin deletes the user
+            admin_client.delete(f"{_ADMIN_USERS_URL}/{user_id}")


### PR DESCRIPTION
## Summary
- Add `tests/e2e/` with pytest + httpx E2E tests running against a live server
- 8 smoke tests (`@pytest.mark.smoke`) — read-only, safe for production post-deploy verification
- 9 full tests — task CRUD lifecycle, user management, data export/import
- Auto-bootstraps a temporary test user via admin API when `E2E_USERNAME` not set
- CI integration: `e2e-tests` job runs full suite on PRs, `smoke-test` job runs after deployment

## Test plan
- [x] All 17 E2E tests pass locally against running server
- [x] All 249 unit tests still pass
- [x] Pre-commit hooks pass (black, isort, flake8, mypy)
- [ ] CI runs E2E tests successfully
- [ ] Add GitHub secrets for post-deploy smoke tests (see below)

## Required manual setup
After merging, add these **repository secrets** for the post-deploy smoke tests:
- `DEPLOY_URL` — deployed application URL (e.g., `https://api.example.com`)
- `E2E_USERNAME` — test user email
- `E2E_PASSWORD` — test user password

Closes #230

🤖 Generated with [Claude Code](https://claude.ai/code)