### PR TITLE
fix(ci): run smoke tests on self-hosted runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,7 @@ jobs:
 
   smoke-test:
     name: Post-Deploy Smoke Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, lan]
     needs: [deploy]
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary

- Fix post-deploy smoke tests timing out with `ConnectTimeout`
- The smoke-test job was running on `ubuntu-latest` (GitHub-hosted runner) but `DEPLOY_URL` points to a LAN server that isn't publicly accessible
- Changed to `[self-hosted, lan]` to match the deploy job

## Root Cause

Failed run: https://github.com/brandstaetter/Taskmanagement-App/actions/runs/24301843330/job/70956442414

All tests failed with `httpx.ConnectTimeout: timed out` because the GitHub-hosted runner couldn't reach the LAN-deployed backend.

## Test plan

- [ ] Merge and verify the next deploy triggers smoke tests that can actually reach the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)