### PR TITLE
fix(ci): use system Python 3.14 for smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,11 @@ jobs:
     
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        report_type: test_results
+        files: junit.xml
 
   mutation-testing:
     name: Mutation Testing

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,16 +139,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
+      - name: Verify Python 3.14
+        run: python3.14 --version
 
       - name: Install poetry
-        run: pip install poetry
+        run: |
+          python3.14 -m pip install --user poetry
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Setup a local virtual environment (if no poetry.toml file)
         run: |
+          poetry env use python3.14
           poetry config virtualenvs.create true --local
           poetry config virtualenvs.in-project true --local
 
@@ -156,7 +157,7 @@ jobs:
         name: Define a cache for the virtual environment based on the dependencies lock file
         with:
           path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}
+          key: smoke-venv-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,7 @@ jobs:
 
   smoke-test:
     name: Post-Deploy Smoke Test
-    runs-on: [self-hosted, lan]
+    runs-on: [self-hosted, deploy]
     needs: [deploy]
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary

- Fix smoke tests failing on self-hosted runner due to Python 3.14 not being in the `actions/setup-python` tool cache
- Use system-installed `python3.14` directly instead of relying on setup-python

## Changes

- Replace `setup-python` with a simple version verification
- Install poetry via `python3.14 -m pip install --user`
- Add `~/.local/bin` to PATH for poetry access
- Explicitly tell poetry to use `python3.14` for the virtualenv
- Use separate cache key `smoke-venv-` to avoid conflicts

## Context

Failed run: https://github.com/brandstaetter/Taskmanagement-App/actions/runs/24303123659/job/70959853995

Error: `The version '3.14' with architecture 'x64' was not found for Ubuntu 25.04`

The self-hosted runner has Python 3.14.3 installed as `python3.14` but not in the actions tool cache.

## Test plan

- [ ] Re-run smoke tests after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)