### PR TITLE
fix(docker): remove invalid COPY for non-existent migrations dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN poetry config virtualenvs.create false \
 # Copy application code
 COPY taskmanagement_app ./taskmanagement_app
 COPY alembic.ini ./
-COPY migrations ./migrations
 
 # Create a non-root user
 RUN useradd -m appuser && chown -R appuser:appuser /app


### PR DESCRIPTION
## Summary
- Remove `COPY migrations ./migrations` from Dockerfile (line 24)
- The `migrations` directory doesn't exist at the project root
- Migrations are stored at `taskmanagement_app/migrations/` and already copied via `COPY taskmanagement_app ./taskmanagement_app`

## Test plan
- [ ] Docker build succeeds
- [ ] Frontend E2E CI (PR brandstaetter/Taskmanagement-frontend#376) passes

🤖 Generated with [Claude Code](https://claude.ai/code)