### PR TITLE
fix(docker): copy README.md for poetry install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir poetry
 
 # Copy dependency files first (better layer caching)
-COPY pyproject.toml poetry.lock ./
+COPY pyproject.toml poetry.lock README.md ./
 
 # Install dependencies (no dev deps for smaller image)
 RUN poetry config virtualenvs.create false \


### PR DESCRIPTION
## Summary
- Add README.md to the COPY command for dependency files
- Poetry needs README.md because pyproject.toml references it

## Problem
```
Error: The current project could not be installed: Readme path `/app/README.md` does not exist.
```

## Test plan
- [ ] Docker build succeeds
- [ ] Frontend E2E CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)