### PR TITLE
fix(docker): add --no-root to poetry install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY pyproject.toml poetry.lock README.md ./
 
 # Install dependencies (no dev deps for smaller image)
 RUN poetry config virtualenvs.create false \
-    && poetry install --only main --no-interaction --no-ansi
+    && poetry install --only main --no-root --no-interaction --no-ansi
 
 # Copy application code
 COPY taskmanagement_app ./taskmanagement_app


### PR DESCRIPTION
## Summary
- Add `--no-root` flag to `poetry install` command
- Prevents Poetry from trying to install the project before app code is copied

## Problem
```
/app/taskmanagement_app does not contain any element
```

Poetry install runs before the `taskmanagement_app` directory is copied (for better Docker layer caching). The `--no-root` flag skips installing the current project, which isn't needed since uvicorn runs the app directly.

## Test plan
- [ ] Docker build succeeds
- [ ] Frontend E2E CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)